### PR TITLE
Fix review test

### DIFF
--- a/spec/features/03_visitor_sees_reviews_for_airport_spec.rb
+++ b/spec/features/03_visitor_sees_reviews_for_airport_spec.rb
@@ -31,7 +31,7 @@ feature "visitor sees list of reviews on airport page" do
     expect(page).to have_content ohare.name
     expect(page).to have_content review_for_ohare.body
 
-    expect(page).not_to have_content review_for_ohare.rating
-    expect(page).not_to have_content review_for_ohare.body
+    expect(page).not_to have_content review_for_logan.rating
+    expect(page).not_to have_content review_for_logan.body
   end
 end


### PR DESCRIPTION
In the test that checks whether reviews for a different airport appear on the airport details page, the test was looking for reviews not to show up for the same airport. I switched it so that it checks that reviews from a different airport do not show up.

Thanks to Mike O and Jesse L for the heads up.